### PR TITLE
Use Java 8 idioms

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
     <groupId>com.github.drrb.rustjava</groupId>
     <artifactId>java-rust-example</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.1-SNAPSHOT</version>
 
     <name>Java Rust Example</name>
     <description>Example of calling a Rust library from Java</description>
@@ -45,7 +45,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <dependency>
             <groupId>net.java.dev.jna</groupId>
             <artifactId>jna</artifactId>
-            <version>4.0.0</version>
+            <version>4.5.2</version>
         </dependency>
 
         <!-- Test Dependencies -->
@@ -61,6 +61,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <version>1.3</version>
             <scope>test</scope>
         </dependency>
+
+        <!-- Direct dependencies on modules that used to be part of the Java SE, for Java 9+ support -->
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.0</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -70,17 +77,17 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
+                <version>3.8.1</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.18.1</version>
+                <version>2.22.2</version>
                 <configuration>
                     <!-- Don't try to load JNA from the host system, use our dependency instead (needed for Appveyor, which has an old JNA on it) -->
                     <argLine>-Djna.nosys=true</argLine>
@@ -93,7 +100,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>1.9.1</version>
+                <version>1.12</version>
                 <executions>
                     <execution>
                         <id>compile-build-addon</id>
@@ -120,7 +127,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <plugin>
                 <artifactId>exec-maven-plugin</artifactId>
                 <groupId>org.codehaus.mojo</groupId>
-                <version>1.2.1</version>
+                <version>1.6.0</version>
                 <executions>
                     <execution>
                         <id>compile-rust-crates</id>
@@ -141,7 +148,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.5.3</version>
+                <version>2.6</version>
                 <configuration>
                     <appendAssemblyId>false</appendAssemblyId>
                     <descriptorRefs>

--- a/pom.xml
+++ b/pom.xml
@@ -169,20 +169,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     </execution>
                 </executions>
             </plugin>
-
-            <plugin>
-                <groupId>org.jasig.maven</groupId>
-                <artifactId>maven-notice-plugin</artifactId>
-                <version>1.0.4</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>generate</goal>
-                        </goals>
-                        <phase>process-resources</phase>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 

--- a/src/main/java/com/github/drrb/javarust/Greetings.java
+++ b/src/main/java/com/github/drrb/javarust/Greetings.java
@@ -36,7 +36,7 @@ public interface Greetings extends Library {
      * Maven will run scripts/rust-compile.sh, which will compile the crate and
      * copy it into target/classes/&lt;platform-specific-name&gt;.
      */
-    Greetings INSTANCE = (Greetings) Native.loadLibrary(JNA_LIBRARY_NAME, Greetings.class);
+    Greetings INSTANCE = Native.loadLibrary(JNA_LIBRARY_NAME, Greetings.class);
 
     /**
      * Passing a parameter to a Rust function

--- a/src/main/java/com/github/drrb/javarust/Main.java
+++ b/src/main/java/com/github/drrb/javarust/Main.java
@@ -28,11 +28,7 @@ public class Main {
     
     public static void main(String[] args) {
         List<String> arguments = asList(args);
-        if (arguments.isEmpty()) {
-            name = "World";
-        } else {
-            name = arguments.get(0);
-        }
+        name = arguments.isEmpty() ? "World" : arguments.get(0);
         Greetings.INSTANCE.printGreeting(name);
     }
     

--- a/src/test/java/com/github/drrb/javarust/GreetingsTest.java
+++ b/src/test/java/com/github/drrb/javarust/GreetingsTest.java
@@ -27,6 +27,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 import static com.github.drrb.javarust.test.Matchers.is;
+import static java.util.stream.Collectors.toList;
 import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertThat;
 
@@ -96,10 +97,9 @@ public class GreetingsTest {
             }
         });
 
-        List<String> greetingStrings = new LinkedList<>();
-        for (Greeting greeting : greetings) {
-            greetingStrings.add(greeting.getText());
-        }
+        List<String> greetingStrings = greetings.stream()
+                .map(Greeting::getText)
+                .collect(toList());
 
         assertThat(greetingStrings, contains("Hello!", "Hello again!"));
     }
@@ -107,10 +107,9 @@ public class GreetingsTest {
     @Test
     public void shouldGetAStructFromRustContainingAnArrayOfStructs() {
         try (GreetingSet result = library.renderGreetings()) {
-            List<String> greetings = new LinkedList<>();
-            for (Greeting greeting : result.getGreetings()) {
-                greetings.add(greeting.getText());
-            }
+            List<String> greetings = result.getGreetings().stream()
+                    .map(Greeting::getText)
+                    .collect(toList());
 
             assertThat(greetings, contains("Hello!", "Hello again!"));
         }


### PR DESCRIPTION
This PR improves the readability of the Java code used in this example 
by adopting idioms introduced in Java 8 and earlier.

These changes intend to make the intent and behavior of the code more visible
by reducing the amount of boilerplate code.

This change also updates various dependencies to the latest compatible minor version,
in order to fix the build process on Java 8+ JDKs.