### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ env:
   - RUST_CHANNEL=stable
   - RUST_CHANNEL=nightly
 matrix:
+  fast_finish: true
     allow_failures:
       - env: RUST_CHANNEL=nightly
 before_install:
@@ -16,3 +17,7 @@ install:
   - rustup toolchain install ${RUST_CHANNEL}
   - rustup override set ${RUST_CHANNEL}
   - rustc --version
+
+cache:
+  directories:
+  - $HOME/.m2


### PR DESCRIPTION

[Caching Dependencies and Directories](https://docs.travis-ci.com/user/caching/) Travis CI can cache content that does not often change, to speed up the build process.

According to the official document [Fast Finishing](https://docs.travis-ci.com/user/build-matrix/#fast-finishing), if some rows in the build matrix are allowed to fail, we can add fast_finish: true to the .travis.yml to get faster feedbacks.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
